### PR TITLE
cleaned up install, added short test config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ In this repository, following a plethora of works before us, we apply DINO(V2) t
 If you are interested in helping out, check the open Issues.
 ## Installation
 
-install.sh **(Recommended)**:
-Clone the repository, and then run the provided installation script. 
+Clone the repository, cd into it, then run the provided installation script. 
 ```shell
-bash install.sh
+pip install uv
+uv sync
+source .venv/bin/activate
+cp _utils.py .venv/lib/python3.10/site-packages/eva/core/models/wrappers/
 ```
-This will create a venv in your *current* directory called 'dino_env'. It will then install the requirements into that venv.
-If you want to install in a different location, you'll need to modify both instances of 'dino_env' in the script.
+This will create a virtual environment with all necessary packages pre-installed called "pathologydino", located as a .venv folder in the same directory as path-fm.
 
 ## Training
 

--- a/dinov2/configs/train/short_test_config.yaml
+++ b/dinov2/configs/train/short_test_config.yaml
@@ -1,0 +1,34 @@
+dino:
+  head_n_prototypes: 131072
+  head_bottleneck_dim: 384
+  do_kde: True
+  kde_loss_weight: .05
+  koleo_loss_weight: 0
+  do_koleo: False
+ibot:
+  separate_head: true
+  head_n_prototypes: 131072
+train:
+  OFFICIAL_EPOCH_LENGTH: 100
+  batch_size_per_gpu: 32
+    #  dataset_path: ImageNet22k
+  centering: sinkhorn_knopp
+    # use_pretrained: True
+student:
+  arch: vit_small
+  patch_size: 14
+  drop_path_rate: 0.4
+  ffn_layer: mlp
+  block_chunks: 4
+  num_register_tokens: 4
+    #  pretrained_weights: /home/dkaplan/.cache/torch/hub/checkpoints/dinov2_vits14_reg4_pretrain.pth
+teacher:
+  momentum_teacher: 0.994
+optim:
+  epochs: 50 #50000
+  weight_decay_end: 0.2
+  base_lr: 2.0e-04  # learning rate for a batch size of 1024
+    #warmup_epochs: 80
+  layerwise_decay: 1.0
+crops:
+  local_crops_size: 98

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,0 @@
-pip install uv
-uv sync
-source .venv/bin/activate
-uv pip install -e .
-uv pip install 'kaiko-eva[vision]'
-cp _utils.py .venv/lib/python3.10/site-packages/eva/core/models/wrappers/
-uv pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu128
-uv pip install -U xformers --index-url https://download.pytorch.org/whl/cu128
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "pathologydino"
 version = "0.1.0"
@@ -5,6 +9,9 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = "==3.10.12"
 dependencies = [
+    "torch==2.8.0",
+    "torchvision>=0.22.1",
+    "torchaudio>=2.7.1",
     "einops>=0.8.1",
     "fvcore>=0.1.5.post20221221",
     "iopath>=0.1.10",
@@ -17,5 +24,20 @@ dependencies = [
     "submitit>=1.5.3",
     "torchmetrics>=1.8.0",
     "wandb>=0.21.0",
+    "kaiko-eva[vision]>=0.3.3",
+    "xformers==0.0.32.post1",
 ]
 
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-cu128" }
+torchvision = { index = "pytorch-cu128" }
+torchaudio = { index = "pytorch-cu128" }
+xformers = { index = "pytorch-cu128" }
+
+[tool.setuptools.packages.find]
+include = ["dinov2*"]

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 source .venv/bin/activate
-CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --master_port=34005 --nproc_per_node=4 dinov2/train/train.py --config-file ./dinov2/configs/train/vits14_reg4.yaml --output-dir ./output_pretrained_on_test train.dataset_path=pathology:root=/data/TCGA/
+CUDA_VISIBLE_DEVICES=0 torchrun --master_port=34001 --nproc_per_node=1 dinov2/train/train.py --config-file ./dinov2/configs/train/vits14_reg4.yaml --output-dir ./output_pretrained_on_test train.dataset_path=pathology:root=/teamspace/studios/this_studio/tcga/
 


### PR DESCRIPTION
currently for getting your code to work with our lightning.ai compute node, i still have to run

`uv pip install --torch-backend=auto torch torchvision`

due to otherwise conflicting cuda kernels

But I think you can just delete install.sh entirely and then modify your pyproject

then the user can simply run `uv sync`  and that's it! uv can handle everything

only exception is user still needs to do your manual kaiko eva eval fix so I edited the README instructions accordingly